### PR TITLE
Add average percent correct and card deck count to response

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,8 +2,6 @@ require('dotenv').config()
 const express = require('express');
 const bodyParser = require('body-parser');
 const mongoose = require('mongoose');
-
-// const postsRoutes = require("./routes/posts")
 const dealCardsRoutes = require("./routes/dealCards")
 
 const app = express();
@@ -52,7 +50,6 @@ app.get("/", (req, res) => {
   res.status(200).json({ message: "Welcome To Card-Deck API" });
 });
 
-// app.use("/api/posts", postsRoutes);
 app.use("/api/v1/deal", dealCardsRoutes);
 
 

--- a/models/dealtCards.js
+++ b/models/dealtCards.js
@@ -5,4 +5,15 @@ const dealtCardsSchema = mongoose.Schema({
   percentCorrect: { type: Number, required: true }
 });
 
+dealtCardsSchema.static('statistics', function() {
+  return this.aggregate([
+    { $group: {
+        _id: null,
+        percentCorrectAvg: { $avg: "$percentCorrect"},
+        percentCorrectSum: { $sum: "$percentCorrect"},
+        countAll: { $sum: 1 }
+    }}
+  ])
+});
+
 module.exports = mongoose.model('dealtCards', dealtCardsSchema);

--- a/models/dealtCards.js
+++ b/models/dealtCards.js
@@ -10,7 +10,6 @@ dealtCardsSchema.static('statistics', function() {
     { $group: {
         _id: null,
         percentCorrectAvg: { $avg: "$percentCorrect"},
-        percentCorrectSum: { $sum: "$percentCorrect"},
         countAll: { $sum: 1 }
     }}
   ])

--- a/models/post.js
+++ b/models/post.js
@@ -1,8 +1,0 @@
-const mongoose = require('mongoose');
-
-const postSchema = mongoose.Schema({
-  title: { type: String, required: true },
-  content: { type: String, required: true }
-});
-
-module.exports = mongoose.model('Post', postSchema);

--- a/routes/dealCards.js
+++ b/routes/dealCards.js
@@ -4,9 +4,7 @@ const router = express.Router();
 const Deck = require('../models/deck.js')
 const DealtCards = require('../models/dealtCards.js')
 
-
-
-router.post("", (req, res, next) => {
+router.post("", async (req, res, next) => {
   const deck = new Deck();
   const shuffledDeck = deck.shuffle();
 
@@ -15,17 +13,25 @@ router.post("", (req, res, next) => {
     percentCorrect: shuffledDeck.percentCorrect()
   })
 
-  dealtCards.save()
-    .then(result => {
-      res.status(201).json({
-        message: 'Cards shuffled and dealt successfully',
-        data: {
-          dealtCardMatrix: result.dealtCardMatrix,
-          percentCorrect: result.percentCorrect
+  try {
+    let savedDeck = await dealtCards.save();
+    let stats = await DealtCards.statistics();
+
+    res.status(201).json({
+      message: 'Cards shuffled and dealt successfully',
+      data: {
+        dealtCardMatrix: savedDeck.dealtCardMatrix,
+        percentCorrect: savedDeck.percentCorrect,
+        statistics: {
+          decksDealt: stats[0].countAll,
+          averagePercentageCorrect: +stats[0].percentCorrectAvg.toFixed(2)
         }
-      })
+      }
     })
-    .catch(result => console.log('Error saving a new post'))
+  } catch (error){
+    console.log(error);
+    res.status(400).json({message: 'Error dealing cards'})
+  }
 });
 
 module.exports = router;

--- a/test/dealCards.test.js
+++ b/test/dealCards.test.js
@@ -20,6 +20,8 @@ describe("Deal Endpoint", () => {
         expect(res.body.data.dealtCardMatrix.length).to.equal(4);
         expect(res.body.data.dealtCardMatrix[0].length).to.equal(13);
         expect(res.body.data.percentCorrect).to.be.a('number');
+        expect(res.body.data.statistics.decksDealt).to.be.a('number');
+        expect(res.body.data.statistics.averagePercentageCorrect).to.be.a('number');
         done();
       });
   });
@@ -37,7 +39,6 @@ describe("Deal Endpoint", () => {
   })
 
   after(done => {
-    console.log('done with test')
     mongoose.connection.db.dropDatabase(() => {
       mongoose.connection.close(done);
     });

--- a/test/dealtCards.test.js
+++ b/test/dealtCards.test.js
@@ -1,0 +1,45 @@
+process.env.NODE_ENV = 'test'
+const app = require("../app");
+const chai = require("chai");
+const mongoose = require("mongoose");
+const DealtCards = require("../models/dealtCards")
+const { assert } = chai;
+
+
+describe("DealtCards Model Test", () => {
+    it("Has DealtCards Attributes", done => {
+      let newDeck = DealtCards.create(
+        {dealtCardMatrix: [['mock deck'],['mock deck'],['mock deck'],['mock deck']], percentCorrect: .2 },
+        (err, newDeck) => {
+          assert.equal(newDeck.dealtCardMatrix.length, 4)
+          assert.equal(newDeck.percentCorrect, .2)
+          assert.property(newDeck, '_id')
+        })
+      done();
+    });
+
+    it("can calculate the statistics of all dealtCards", done => {
+
+      let newDecks = [
+        {dealtCardMatrix: ['mock deck'], percentCorrect: .2 },
+        {dealtCardMatrix: ['mock deck'], percentCorrect: .15 },
+        {dealtCardMatrix: ['mock deck'], percentCorrect: .1 },
+        {dealtCardMatrix: ['mock deck'], percentCorrect: .3 },
+      ]
+      DealtCards.create(newDecks, async(err, dealtCard) => {
+        let stats = await DealtCards.statistics()
+
+        assert.equal(stats[0].percentCorrectAvg, 0.1875)
+        assert.equal(stats[0].countAll, 4)
+      })
+      done();
+    })
+
+    afterEach(done => {
+      console.log('done with test')
+      mongoose.connection.db.dropDatabase(() => {
+        mongoose.connection.close(done);
+      });
+    });
+
+})


### PR DESCRIPTION
In `models/dealtCards.js` the static `statistics` is added to calculate the average percentCorrect score across all dealtcards in the collection.

This output is then added to the `/deal` response. To accommodate multiple calls to the db, it is refactored into asycn with try/catch.

Tests are added for the DealtCards model as well.

Closes #7 